### PR TITLE
Update dragoneye node library to deserialize parquets

### DIFF
--- a/examples/test_video.ts
+++ b/examples/test_video.ts
@@ -1,0 +1,48 @@
+/**
+ * npx dotenv-cli -e .env.local -- npx ts-node examples/test_video.ts
+ */
+
+import { Dragoneye } from "../src";
+
+const VIDEO_PATH = "/path/to/your/video.mp4";
+const MODEL_NAME = "recognize_anything/model_name";
+const FRAMES_PER_SECOND = 1;
+
+async function main() {
+  const client = new Dragoneye({ apiKey: process.env.DRAGONEYE_API_KEY });
+  const media = await Dragoneye.Video.fromFilePath(VIDEO_PATH);
+
+  console.log("Starting prediction...");
+  const result = await client.classification.predictVideo(
+    media,
+    MODEL_NAME,
+    FRAMES_PER_SECOND
+  );
+
+  console.log("\nFull response:");
+  console.log(JSON.stringify(result, null, 2));
+
+  console.log("\n--- Parsed predictions ---\n");
+  console.log(`Frames per second: ${result.frames_per_second}`);
+  for (const [timestampUs, objectPredictions] of Object.entries(
+    result.timestamp_us_to_predictions
+  )) {
+    console.log(`\nTimestamp (us): ${timestampUs}`);
+    for (const obj of objectPredictions) {
+      console.log("  Bbox:", obj.normalizedBbox);
+      for (const pred of obj.predictions) {
+        console.log(
+          `    Category: ${pred.category.name} (score: ${pred.category.score})`
+        );
+        for (const attr of pred.attributes) {
+          console.log(`      Attribute: ${attr.name}`);
+          for (const opt of attr.options) {
+            console.log(`        ${opt.name}: ${opt.score}`);
+          }
+        }
+      }
+    }
+  }
+}
+
+main().catch(console.error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,18 @@
 {
   "name": "dragoneye-node",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dragoneye-node",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.8",
-        "exponential-backoff": "^3.1.2"
+        "exponential-backoff": "^3.1.2",
+        "hyparquet": "^1.10.0",
+        "hyparquet-compressors": "^1.1.1"
       },
       "devDependencies": {
         "@types/node": "^24.3.0",
@@ -118,22 +120,38 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -151,17 +169,78 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/exponential-backoff": {
@@ -171,15 +250,16 @@
       "license": "Apache-2.0"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -190,17 +270,145 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fzstd": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz",
+      "integrity": "sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==",
+      "license": "MIT"
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hyparquet": {
+      "version": "1.25.6",
+      "resolved": "https://registry.npmjs.org/hyparquet/-/hyparquet-1.25.6.tgz",
+      "integrity": "sha512-Q9W5IjkVch3ZMnYd4qFv2q8suu5Jc36yt7J+zUNM9grwnP1S189icp0jdEQKM5HJvQkTVy8NMiQ8n/dM5QAt1A==",
+      "license": "MIT"
+    },
+    "node_modules/hyparquet-compressors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hyparquet-compressors/-/hyparquet-compressors-1.1.1.tgz",
+      "integrity": "sha512-yx7aA3Rhj0YycbdV71+XznQSLAefa4cT0urpgNXy4aM6eSeCknaVDNne8y45Uz74Fb15yyXUzOStlceOJBan7A==",
+      "license": "MIT",
+      "dependencies": {
+        "fzstd": "0.1.1",
+        "hysnappy": "1.0.0"
+      }
+    },
+    "node_modules/hysnappy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hysnappy/-/hysnappy-1.0.0.tgz",
+      "integrity": "sha512-MNrC4NfwDGPb889O6gIfEtbvEZCSWUsSEhsz4Oq2FRcpGtXHfeVz3KciSPp5Pnnz1NjFMgDQNfxdJozymJEDDA==",
+      "license": "MIT"
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -208,10 +416,20 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -220,6 +438,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -228,9 +447,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/ts-node": {
       "version": "10.9.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dragoneye-node",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "The official TypeScript library for the Dragoneye API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -28,6 +28,8 @@
   },
   "dependencies": {
     "axios": "^1.6.8",
-    "exponential-backoff": "^3.1.2"
+    "exponential-backoff": "^3.1.2",
+    "hyparquet": "^1.10.0",
+    "hyparquet-compressors": "^1.1.1"
   }
 }

--- a/src/classification.ts
+++ b/src/classification.ts
@@ -22,6 +22,10 @@ import type {
   ClassificationPredictVideoResponse,
   PredictionTaskStatusResponse,
 } from "./models";
+import {
+  deserializeImagePredictions,
+  deserializeVideoPredictions,
+} from "./parquetDeserializer";
 
 // ---- Internal API shapes ----
 interface PresignedPostRequest {
@@ -232,8 +236,7 @@ export class Classification {
 
     const form = new FormData();
     form.append("mimetype", mimeType);
-    form.append("response_version", "object");
-
+    form.append("response_version", "parquet");
     if (name) {
       form.append("file_name", name);
     }
@@ -256,6 +259,11 @@ export class Classification {
         "Error beginning prediction task:",
         error
       );
+    }
+
+    if (resp.status === 400) {
+      const payload = (await resp.json()) as { detail?: string };
+      throw new PredictionTaskBeginError(payload.detail ?? "");
     }
 
     if (!resp.ok) {
@@ -377,9 +385,11 @@ export class Classification {
   ): Promise<
     ClassificationPredictImageResponse | ClassificationPredictVideoResponse
   > {
-    const url = `${BASE_API_URL}/prediction-task/results?predictionTaskUuid=${encodeURIComponent(
-      predictionTaskUuid as unknown as string
-    )}`;
+    const url =
+      `${BASE_API_URL}/prediction-task/results` +
+      `?predictionTaskUuid=${encodeURIComponent(
+        predictionTaskUuid as unknown as string
+      )}&response_version=parquet`;
 
     let resp: Response;
     try {
@@ -396,25 +406,46 @@ export class Classification {
       );
     }
 
+    if (resp.status === 400) {
+      const payload = (await resp.json()) as { detail?: string };
+      throw new PredictionTaskResultsUnavailableError(payload.detail ?? "");
+    }
+
     if (!resp.ok) {
       throw new PredictionTaskResultsUnavailableError(
         `Error getting prediction task results: ${resp.status} ${resp.statusText}`
       );
     }
 
-    const payload = await resp.json();
-
-    // Add the prediction task uuid to the response before returning
-    const augmented = {
-      ...payload,
-      prediction_task_uuid: predictionTaskUuid,
-    };
+    const parquetBytes = await resp.arrayBuffer();
+    const originalFileName = resp.headers.get("X-Original-File-Name") ?? null;
 
     switch (predictionType) {
-      case "image":
-        return augmented as ClassificationPredictImageResponse;
-      case "video":
-        return augmented as ClassificationPredictVideoResponse;
+      case "image": {
+        const object_predictions = await deserializeImagePredictions(parquetBytes);
+        return {
+          object_predictions,
+          prediction_task_uuid: predictionTaskUuid,
+          original_file_name: originalFileName,
+        } satisfies ClassificationPredictImageResponse;
+      }
+      case "video": {
+        const framesPerSecondHeader = resp.headers.get("X-Frames-Per-Second");
+        if (framesPerSecondHeader === null) {
+          throw new PredictionTaskResultsUnavailableError(
+            "Missing X-Frames-Per-Second header on video prediction response"
+          );
+        }
+        const timestamp_us_to_predictions = await deserializeVideoPredictions(
+          parquetBytes
+        );
+        return {
+          timestamp_us_to_predictions,
+          frames_per_second: Number(framesPerSecondHeader),
+          prediction_task_uuid: predictionTaskUuid,
+          original_file_name: originalFileName,
+        } satisfies ClassificationPredictVideoResponse;
+      }
     }
   }
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -3,8 +3,6 @@ export type Brand<T, B extends string> = T & { readonly __brand: B };
 
 export type NormalizedBbox = [number, number, number, number];
 
-export type TimestampUs = Brand<number, "TimestampUs">;
-
 export type PredictionType = "image" | "video";
 
 export type PredictionTaskState = Brand<string, "PredictionTaskState">;

--- a/src/esmImport.ts
+++ b/src/esmImport.ts
@@ -1,0 +1,18 @@
+// Utilities for loading ESM-only dependencies from this CommonJS package.
+//
+// A static `import` of an ESM-only module would force our consumers onto ESM,
+// and `await import(...)` is transpiled to `require(...)` under
+// "module": "commonjs", which fails at runtime for ESM-only packages. The
+// Function wrapper below preserves a real dynamic `import()` call in the
+// emitted JS, giving us runtime ESM interop while keeping the package CJS.
+
+export const dynamicImport = new Function(
+  "specifier",
+  "return import(specifier)"
+) as <T = unknown>(specifier: string) => Promise<T>;
+
+// Memoize an async loader so repeated callers share one import promise.
+export function lazy<T>(load: () => Promise<T>): () => Promise<T> {
+  let promise: Promise<T> | undefined;
+  return () => (promise ??= load());
+}

--- a/src/exception.ts
+++ b/src/exception.ts
@@ -37,3 +37,4 @@ export class IncorrectMediaTypeError extends Error {
     this.name = "IncorrectMediaTypeError";
   }
 }
+

--- a/src/models.ts
+++ b/src/models.ts
@@ -13,7 +13,7 @@ export interface PredictionTaskStatusResponse {
   status: PredictionTaskState;
 }
 
-// ---- Classification prediction types ----
+// ---- Shared prediction types ----
 export interface ClassificationAttributeOption {
   option_id: number;
   name: string;
@@ -45,8 +45,8 @@ export interface ClassificationObjectPrediction {
 // ---- Image predictions ----
 export interface ClassificationPredictImageResponse {
   object_predictions: ClassificationObjectPrediction[];
-  original_file_name?: string;
   prediction_task_uuid: PredictionTaskUUID;
+  original_file_name?: string | null;
 }
 
 // ---- Video predictions ----
@@ -62,6 +62,6 @@ export interface ClassificationPredictVideoResponse {
     ClassificationVideoObjectPrediction[]
   >;
   frames_per_second: number;
-  original_file_name?: string;
   prediction_task_uuid: PredictionTaskUUID;
+  original_file_name?: string | null;
 }

--- a/src/parquetDeserializer.ts
+++ b/src/parquetDeserializer.ts
@@ -1,0 +1,147 @@
+// parquetDeserializer.ts
+import type {
+  ClassificationAttributeOption,
+  ClassificationAttributeResponse,
+  ClassificationCategory,
+  ClassificationCategoryPrediction,
+  ClassificationObjectPrediction,
+  ClassificationVideoObjectPrediction,
+} from "./models";
+import type { NormalizedBbox } from "./common";
+import { dynamicImport, lazy } from "./esmImport";
+
+const loadEsmDeps = lazy(async () => {
+  const [hyparquet, hyparquetCompressors] = await Promise.all([
+    dynamicImport<typeof import("hyparquet")>("hyparquet"),
+    dynamicImport<typeof import("hyparquet-compressors")>("hyparquet-compressors"),
+  ]);
+  return {
+    parquetReadObjects: hyparquet.parquetReadObjects,
+    compressors: hyparquetCompressors.compressors,
+  };
+});
+
+// Row shape after parquet decoding. Matches the server-side schema:
+// image_id:           string
+// normalized_bbox:    Float64[4]
+// bbox_score:         number
+// predictions:        RawPrediction[]
+// timestamp_microseconds (video only): number | bigint
+// hyparquet decodes parquet INT64 columns as bigint, so id fields arrive as
+// number | bigint and must be narrowed before leaving this module.
+interface RawOption {
+  option_id: number | bigint;
+  name: string;
+  score: number;
+}
+
+interface RawAttribute {
+  attribute_id: number | bigint;
+  name: string;
+  options: RawOption[];
+}
+
+interface RawPrediction {
+  category_id: number | bigint;
+  name: string;
+  score: number;
+  attributes: RawAttribute[];
+}
+
+// hyparquet returns `undefined` (not `null`) for null parquet cells, so every
+// nullable column must include `undefined` in its type — casts on these fields
+// would otherwise silently lie.
+interface RawRow {
+  image_id: string;
+  normalized_bbox: [number, number, number, number] | null | undefined;
+  bbox_score: number | null | undefined;
+  predictions: RawPrediction[] | null | undefined;
+  timestamp_microseconds?: number | bigint | null | undefined;
+}
+
+function toNumber(value: number | bigint): number {
+  return typeof value === "bigint" ? Number(value) : value;
+}
+
+function predictionsToModels(
+  raw: RawPrediction[] | null | undefined
+): ClassificationCategoryPrediction[] {
+  if (!raw) return [];
+  return raw.map((pred) => ({
+    category: {
+      id: toNumber(pred.category_id),
+      name: pred.name,
+      score: pred.score,
+    } satisfies ClassificationCategory,
+    attributes: (pred.attributes ?? []).map(
+      (attr): ClassificationAttributeResponse => ({
+        attribute_id: toNumber(attr.attribute_id),
+        name: attr.name,
+        options: (attr.options ?? []).map(
+          (opt): ClassificationAttributeOption => ({
+            option_id: toNumber(opt.option_id),
+            name: opt.name,
+            score: opt.score,
+          })
+        ),
+      })
+    ),
+  }));
+}
+
+function toAsyncBuffer(buffer: ArrayBuffer) {
+  return {
+    byteLength: buffer.byteLength,
+    slice(start: number, end?: number) {
+      return buffer.slice(start, end);
+    },
+  };
+}
+
+async function readRows(parquetBytes: ArrayBuffer): Promise<RawRow[]> {
+  const { parquetReadObjects, compressors } = await loadEsmDeps();
+  const rows = await parquetReadObjects({
+    file: toAsyncBuffer(parquetBytes),
+    compressors,
+  });
+  return rows as unknown as RawRow[];
+}
+
+export async function deserializeImagePredictions(
+  parquetBytes: ArrayBuffer
+): Promise<ClassificationObjectPrediction[]> {
+  const rows = await readRows(parquetBytes);
+  return rows
+    .filter((row) => row.normalized_bbox != null)
+    .map((row) => ({
+      normalizedBbox: row.normalized_bbox as NormalizedBbox,
+      predictions: predictionsToModels(row.predictions),
+    }));
+}
+
+export async function deserializeVideoPredictions(
+  parquetBytes: ArrayBuffer
+): Promise<Record<number, ClassificationVideoObjectPrediction[]>> {
+  const rows = await readRows(parquetBytes);
+  const result: Record<number, ClassificationVideoObjectPrediction[]> = {};
+
+  for (const row of rows) {
+    if (row.timestamp_microseconds == null) {
+      continue;
+    }
+    const ts = toNumber(row.timestamp_microseconds);
+    if (result[ts] === undefined) {
+      result[ts] = [];
+    }
+    if (row.normalized_bbox != null) {
+      result[ts].push({
+        normalizedBbox: row.normalized_bbox as NormalizedBbox,
+        predictions: predictionsToModels(row.predictions),
+        frame_id: row.image_id,
+        timestamp_microseconds: ts,
+      });
+    }
+  }
+
+  return result;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
-
     /* Projects */
     // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
     // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
@@ -9,9 +8,8 @@
     // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
     // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2017", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
@@ -23,12 +21,10 @@
     // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
-
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "module": "commonjs", /* Specify what module code is generated. */
+    "rootDir": "./src", /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
-    "baseUrl": "./src",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
@@ -42,20 +38,18 @@
     // "resolveJsonModule": true,                        /* Enable importing .json files. */
     // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
-
     /* JavaScript Support */
     // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
     // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
-
     /* Emit */
-    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declaration": true, /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "dist",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "dist", /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
@@ -72,17 +66,15 @@
     // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
     // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
     // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
-
     /* Interop Constraints */
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
-
+    "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
     /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
+    "strict": true, /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
@@ -101,10 +93,11 @@
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
     // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "include": ["./src/**/*.ts"]
+  "include": [
+    "./src/**/*.ts"
+  ]
 }


### PR DESCRIPTION
Update the node library to correctly deserialize parquets rather than expect object responses. This will improve performance.