### PR TITLE
[4/n] - Support gap frames in the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,13 @@ Below is an example of what a `ClassificationPredictVideoResponse` looks like fo
       timestamp_ranges: [
         { timestamp_start_us_inclusive: 0, timestamp_end_us_inclusive: 1000000 },
       ],
-      // One observation per sampled frame the object appeared in.
+      // One observation per processed frame in the object's lifespan. Detected
+      // frames carry a real bbox under `observation`; gap frames (predicted
+      // present but not detected on that frame) carry `observation: null`.
       bbox_observations: [
-        { timestamp_microseconds: 0, normalized_bbox: [0.12, 0.25, 0.55, 0.78], bbox_score: 0.94 },
-        { timestamp_microseconds: 1000000, normalized_bbox: [0.13, 0.26, 0.56, 0.79], bbox_score: 0.91 },
+        { timestamp_microseconds: 0, observation: { normalized_bbox: [0.12, 0.25, 0.55, 0.78], bbox_score: 0.94 } },
+        { timestamp_microseconds: 500000, observation: null },
+        { timestamp_microseconds: 1000000, observation: { normalized_bbox: [0.13, 0.26, 0.56, 0.79], bbox_score: 0.91 } },
       ],
       categories: [
         {
@@ -195,7 +198,7 @@ Below is an example of what a `ClassificationPredictVideoResponse` looks like fo
         { timestamp_start_us_inclusive: 0, timestamp_end_us_inclusive: 0 },
       ],
       bbox_observations: [
-        { timestamp_microseconds: 0, normalized_bbox: [0.60, 0.30, 0.88, 0.75], bbox_score: 0.87 },
+        { timestamp_microseconds: 0, observation: { normalized_bbox: [0.60, 0.30, 0.88, 0.75], bbox_score: 0.87 } },
       ],
       categories: [
         {
@@ -228,7 +231,7 @@ Image responses collapse the time dimension: one bounding box per object and one
 ClassificationPredictImageResponse
 └── objects: ImageDetectedObject[]
     ├── object_id: number
-    ├── bbox_observation: ImageBboxObservation
+    ├── bbox_observation: BboxObservation
     │   └── { normalized_bbox: [x_min, y_min, x_max, y_max], bbox_score }
     └── categories: ImageCategoryPrediction[]
         ├── { category_id, name, score }
@@ -244,15 +247,14 @@ ClassificationPredictVideoResponse
     ├── object_id: number
     ├── timestamp_ranges: TimestampRange[] { timestamp_start_us_inclusive, timestamp_end_us_inclusive }
     ├── bbox_observations: VideoBboxObservation[]
-    │   └── { timestamp_microseconds, normalized_bbox: [x_min, y_min, x_max, y_max], bbox_score }
+    │   └── { timestamp_microseconds, observation: BboxObservation | null }
+    │       observation: { normalized_bbox: [x_min, y_min, x_max, y_max], bbox_score } | null (gap frame)
     └── categories: VideoCategoryPrediction[]
         ├── { category_id, name, score }
         └── attributes: VideoAttributePrediction[]
             └── { attribute_id, attribute_name, option_id, option_name,
                   timestamp_ranges: ScoredTimestampRange[] { timestamp_start_us_inclusive, timestamp_end_us_inclusive, score } }
 ```
-
-> **Note — Breaking change (v5)**: The previous unprefixed `DetectedObject`, `BboxObservation`, `CategoryPrediction`, and `AttributePrediction` types were removed. Image consumers now read `obj.bbox_observation.normalized_bbox` (was `obj.bbox_observations[0].normalized_bbox`) and `attr.score` (was `attr.timestamp_ranges[0].score`). The parquet/wire format is unchanged — this is purely a client-side type change.
 
 ---
 
@@ -297,18 +299,18 @@ export interface ScoredTimestampRange {
 }
 ```
 
-### Image types
+#### **`BboxObservation`**
 
-#### **`ImageBboxObservation`**
-
-The bounding box of a detected object in an image. `normalized_bbox` is `[x_min, y_min, x_max, y_max]` in `0..1`.
+A single bounding-box detection: the box and its score, always present together. `normalized_bbox` is `[x_min, y_min, x_max, y_max]` in `0..1`. Both fields are **required** — a `BboxObservation` always represents a real detection. The absence of a detection (a video gap frame) is modeled one level up by [`VideoBboxObservation`](#videobboxobservation) making its `observation` field nullable. Images use `BboxObservation` directly; they never have gap frames.
 
 ```typescript
-export interface ImageBboxObservation {
+export interface BboxObservation {
   normalized_bbox: NormalizedBbox;
   bbox_score: number;
 }
 ```
+
+### Image types
 
 #### **`ImageAttributePrediction`**
 
@@ -344,7 +346,7 @@ A single detected object in an image. `object_id` is stable within the response;
 ```typescript
 export interface ImageDetectedObject {
   object_id: number;
-  bbox_observation: ImageBboxObservation;
+  bbox_observation: BboxObservation;
   categories: ImageCategoryPrediction[];
 }
 ```
@@ -353,13 +355,14 @@ export interface ImageDetectedObject {
 
 #### **`VideoBboxObservation`**
 
-A single bounding-box observation of a tracked object at one timestamp. `normalized_bbox` is `[x_min, y_min, x_max, y_max]` in `0..1`.
+A single bounding-box observation of a tracked object at one timestamp. `timestamp_microseconds` is always present; `observation` is a [`BboxObservation`](#bboxobservation) or `null`.
+
+A video object accumulates one observation per processed frame within its lifespan. Frames where the track was **detected** carry a real bbox under `observation`; **gap frames** — frames inside the lifespan where the track was predicted present but not detected — carry `observation: null`. These observations are kept (not filtered out) so present-but-undetected frames stay visible.
 
 ```typescript
 export interface VideoBboxObservation {
   timestamp_microseconds: number;
-  normalized_bbox: NormalizedBbox;
-  bbox_score: number;
+  observation: BboxObservation | null;
 }
 ```
 

--- a/examples/test_video.ts
+++ b/examples/test_video.ts
@@ -33,8 +33,14 @@ async function main() {
       .join(", ");
     console.log(`\nObject ${obj.object_id} (us ${presence}):`);
     for (const bbox of obj.bbox_observations) {
+      // Gap frames (the track was predicted present but not detected on this
+      // frame) carry a null observation.
+      if (bbox.observation === null) {
+        console.log(`  ts=${bbox.timestamp_microseconds}us Bbox: (gap frame, not detected)`);
+        continue;
+      }
       console.log(
-        `  ts=${bbox.timestamp_microseconds}us Bbox: ${JSON.stringify(bbox.normalized_bbox)} (score: ${bbox.bbox_score})`
+        `  ts=${bbox.timestamp_microseconds}us Bbox: ${JSON.stringify(bbox.observation.normalized_bbox)} (score: ${bbox.observation.bbox_score})`
       );
     }
     for (const category of obj.categories) {

--- a/src/models.ts
+++ b/src/models.ts
@@ -35,11 +35,15 @@ export interface ScoredTimestampRange {
   score: number;
 }
 
-// ---- Shared bases ----
+// ---- Shared value objects ----
 
-// Fields shared by every bounding-box sighting, image or video.
-interface BboxObservationBase {
-  // normalized_bbox is [x1, y1, x2, y2] in 0..1.
+// A single bounding-box detection: the box and its score, always present
+// together. This is the "real detection" value object — both fields are
+// required, so a non-null BboxObservation guarantees both are set. Absence of a
+// detection (video gap frames) is modeled at the level above by making the
+// containing field nullable.
+export interface BboxObservation {
+  // [x1, y1, x2, y2] in 0..1.
   normalized_bbox: NormalizedBbox;
   bbox_score: number;
 }
@@ -61,9 +65,6 @@ interface CategoryPredictionBase {
 
 // ---- Image (timestamp-free) ----
 
-// The bounding box of a detected object in an image.
-export interface ImageBboxObservation extends BboxObservationBase {}
-
 // A chosen attribute option for an object in an image, with its score.
 export interface ImageAttributePrediction extends AttributePredictionBase {
   score: number;
@@ -75,18 +76,24 @@ export interface ImageCategoryPrediction extends CategoryPredictionBase {
 
 // One detected object in an image: its bounding box and categories. Unlike
 // VideoDetectedObject, an image object has no time dimension — a single
-// ImageBboxObservation and a single score per attribute.
+// BboxObservation and a single score per attribute. Images never have gap
+// frames, so the bbox is always present.
 export interface ImageDetectedObject {
   object_id: number;
-  bbox_observation: ImageBboxObservation;
+  bbox_observation: BboxObservation;
   categories: ImageCategoryPrediction[];
 }
 
 // ---- Video (time-aware) ----
 
-// One bounding-box sighting of a tracked object at a single timestamp.
-export interface VideoBboxObservation extends BboxObservationBase {
+// One bounding-box sighting of a tracked object at a single timestamp. The
+// timestamp is always present, but `observation` is null on "predicted-but-
+// undetected" gap frames — frames inside a track's lifespan where the track
+// wasn't detected. Only video produces gap frames; image objects always carry a
+// real bbox.
+export interface VideoBboxObservation {
   timestamp_microseconds: number;
+  observation: BboxObservation | null;
 }
 
 // A chosen attribute option together with the time runs over which it won. The

--- a/src/parquetDeserializer.ts
+++ b/src/parquetDeserializer.ts
@@ -9,8 +9,8 @@
 import { parquetReadObjects } from "hyparquet";
 import { decompress as zstdDecompress } from "fzstd";
 import type {
+  BboxObservation,
   ImageAttributePrediction,
-  ImageBboxObservation,
   ImageCategoryPrediction,
   ImageDetectedObject,
   ScoredTimestampRange,
@@ -62,16 +62,29 @@ function parseScoredTimestampRange(value: unknown): ScoredTimestampRange {
   };
 }
 
+// Builds a real detection from a struct that is known to carry one — both the
+// box and its score are present. The gap-frame branch lives at the caller, so
+// this helper never sees nulls. Floats read straight from the parquet list — no
+// per-element coercion.
+function toBboxObservation(value: Record<string, unknown>): BboxObservation {
+  return {
+    normalized_bbox: value["normalized_bbox"] as NormalizedBbox,
+    bbox_score: value["bbox_score"] as number,
+  };
+}
+
 // ---- Video: straight structural map ----
 
 function parseVideoBboxObservation(
   value: Record<string, unknown>
 ): VideoBboxObservation {
+  // Gap frames (predicted-but-undetected frames inside a track's lifespan) emit
+  // null for the bbox on the wire; hyparquet surfaces null cells as `undefined`.
+  // The timestamp is always present; only the observation goes null.
+  const normalizedBbox = value["normalized_bbox"];
   return {
     timestamp_microseconds: toNumber(value["timestamp_microseconds"]),
-    // Floats read straight from the parquet list — no per-element coercion.
-    normalized_bbox: value["normalized_bbox"] as NormalizedBbox,
-    bbox_score: value["bbox_score"] as number,
+    observation: normalizedBbox == null ? null : toBboxObservation(value),
   };
 }
 
@@ -122,14 +135,6 @@ function rowToVideoDetectedObject(
 
 // ---- Image: collapse the time dimension ----
 
-function toImageBbox(value: Record<string, unknown>): ImageBboxObservation {
-  return {
-    // Drop timestamp_microseconds — images are timestamp-free.
-    normalized_bbox: value["normalized_bbox"] as NormalizedBbox,
-    bbox_score: value["bbox_score"] as number,
-  };
-}
-
 function parseImageAttributePrediction(
   value: Record<string, unknown>
 ): ImageAttributePrediction {
@@ -170,10 +175,12 @@ function rowToImageDetectedObject(
     [];
   const categories =
     (row["categories"] as Record<string, unknown>[] | null | undefined) ?? [];
-  // Images always have exactly one bbox observation; take the first.
+  // Images always have exactly one bbox observation and are never gap frames;
+  // take the first and build a real detection. A null bbox here would surface
+  // as a malformed value rather than being silently masked — intentional.
   return {
     object_id: toNumber(row["object_id"]),
-    bbox_observation: toImageBbox(bboxObservations[0] ?? {}),
+    bbox_observation: toBboxObservation(bboxObservations[0] ?? {}),
     categories: categories.map(parseImageCategoryPrediction),
   };
 }


### PR DESCRIPTION
Update the node api to support gap frames. The pipeline returns the timestamps for objects where they are on screen but have no bbox. We need to type for that.